### PR TITLE
Path update reduction

### DIFF
--- a/octave/sonota/PPL.m
+++ b/octave/sonota/PPL.m
@@ -45,22 +45,22 @@ function V = PPL (H, HE, X, Nsybl, Npath, lp)
     # 減算部分の導出
     LUUH_SET = zeros(Nsybl,Nsybl);
 
-    l = 2:Nsybl;
-    LUUH = zeros(Nsybl,Nsybl,Nsybl);
-    SUB_PART = zeros(Nsybl,Nsybl);
+%    l = 2:Nsybl;
+%    LUUH = zeros(Nsybl,Nsybl,Nsybl);
+%    SUB_PART = zeros(Nsybl,Nsybl);
 
-    Xn(:,l-1) = Xpre(:,l);
+%    Xn(:,l-1) = Xpre(:,l);
 
-    U(:,l-1) = Xpre(:,l-1);
+%    U(:,l-1) = Xpre(:,l-1);
 
-    UH = U';
+%    UH = U';
 
-    LU(:,l-1) = LAMBDA(l-1).*U(:,l-1);
+%    LU(:,l-1) = LAMBDA(l-1).*U(:,l-1);
 
-    for j=2:Nsybl
-        k = 1:l(j)
-        SUB_PART(:,j) = LU(:,k) * UH(k,:) * Xn(:,j-1);
-    end
+%    for j=2:Nsybl
+%        k = 1:l(j)
+%        SUB_PART(:,j) = LU(:,k) * UH(k,:) * Xn(:,j-1);
+%    end
 %    for k=2:Nsybl
 %        LUUH(:,:,k) = LU(:,k-1) * UH(k-1,:);
 %    end 
@@ -72,31 +72,31 @@ function V = PPL (H, HE, X, Nsybl, Npath, lp)
 %        SUB_PART(:,k) = LUUH(:,:,k) * Xn(:,k-1);
 %    end
 
-%    for l=2:Nsybl
-%      # 収束する固有ベクトル
-%      Xn(:,1) = Xpre(:,l);
-%
-%      # 減算する固有ベクトル
-%      U(:,1) = Xpre(:,l-1);
-%
-%      # 固有ベクトルの随伴行列
-%      UH = U';
-%
-%      # λ*U
-%      LU = LAMBDA(l-1)*U;
-%
-%      # LU*UH
-%      LUUH = LU * UH;
-%
-%      # LUUHの集合を格納
-%      LUUH_SET = LUUH_SET + LUUH;
-%
-%      # LUUH_SET*Xn
-%      LUUHXn = LUUH_SET * Xn;
-%      
-%      # 減算部の格納
-%      SUB_PART(:,l) = LUUHXn(:,1);
-%    end
+    for l=2:Nsybl
+      # 収束する固有ベクトル
+      Xn(:,1) = Xpre(:,l);
+
+      # 減算する固有ベクトル
+      U(:,1) = Xpre(:,l-1);
+
+      # 固有ベクトルの随伴行列
+      UH = U';
+
+      # λ*U
+      LU = LAMBDA(l-1)*U;
+
+      # LU*UH
+      LUUH = LU * UH;
+
+      # LUUHの集合を格納
+      LUUH_SET = LUUH_SET + LUUH;
+
+      # LUUH_SET*Xn
+      LUUHXn = LUUH_SET * Xn;
+      
+      # 減算部の格納
+      SUB_PART(:,l) = LUUHXn(:,1);
+    end
     arSUB = HHHX - SUB_PART;
 
     l=1:Nsybl;


### PR DESCRIPTION
毎ループ伝搬路の更新を行うと、それに伴うPPLで実行時間が長い。
100回に1回程度に伝搬路更新を減らし、プログラムの高速化を図る。